### PR TITLE
WIP: Change behaviour to automatically apply changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,33 @@
-## Vimiv BatchMark
+## Vimiv Batch Mark
 > [vimiv](https://github.com/karlch/vimiv-qt) plugin for batch marking images
 
-Vimiv BatchMark lets you easily mark contiguous images
+Vimiv Batch Mark lets you easily mark contiguous images.
 
 ### Installation
 - Clone this project into `$XDG_DATA_HOME/vimiv/plugins/`.
-- Activate Vimiv BatchMark by adding `batchmark =` to the `PLUGINS` section of `$XDG_CONFIG_HOME/vimiv/vimiv.conf`.
+- Activate Vimiv Batch Mark by adding `batchmark =` to the `PLUGINS` section of `$XDG_CONFIG_HOME/vimiv/vimiv.conf`.
 
 ### Usage
 - Select the first image you want to mark
-- Run `:batchmark-start`
+- Run `:batchmark-toggle`
 - Select the last image you want to mark
-- Run `:batchmark-end`
+- Run `:batchmark-toggle`
 
-If at least one image in the range is not marked, all images get marked. If all images are already marked, the all get unmarked.
+In case the start image is currently marked, all images in the selection will be unmarked. Otherwise, all images in the selection will be marked.
+
+The selection can be undone by calling `batchmark-cancel`. Pressing `ESC` has the same effect.
 
 ### Commands
 
-- `batchmark-start`: Start BatchMark selector at current image.
+- `batchmark-start`: Start Batch Mark Selection at current image.
 
-- `batchmark-end`: EndBatch Mark selection at current image. If the selection is valid the selected images are (un)marked.
+- `batchmark-accept`: End Batch Mark Selection at current image.
 
-- `batchmark-toggle`: Starts/ends a BatchMark selection depending if we have started on already. Binding this command to e.g. `V` in vimiv would result in similar functionality as Vims visual mode.
+- `batchmark-toggle`: Dynamically start or end the Batch Mark Selection. Binding this command to e.g. `v` in vimiv would result in similar functionality as Vims visual mode.
 
-- `batchmark-cancel`: Cancels an already started Batch Mark selection.
+- `batchmark-cancel`: Cancels an already started Batch Mark Selection.
 
 ### Status Bar Module
-BatchMark provides the status bar module `{batchmark}`. It indicates if a BatchMark has been started and if the current Batch Mark got invalid due to a change of path.
+Batch Mark provides the status bar module `{batchmark}`. It indicates if a Batch Mark Selection has been started.
 
 For instruction on how to enable it please consult the [vimiv docs](https://karlch.github.io/vimiv-qt/documentation/configuration/statusbar.html).

--- a/__init__.py
+++ b/__init__.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+from PyQt5.QtCore import QObject
+
 from vimiv import api
 from vimiv.config import styles
 from vimiv.utils import log, wrap_style_span
@@ -9,7 +11,7 @@ from vimiv.utils import log, wrap_style_span
 _logger = log.module_logger(__name__)
 
 
-class BatchMark:
+class BatchMark(QObject):
     class STATUS:
         invalid = 0
         idle = 1
@@ -17,62 +19,77 @@ class BatchMark:
 
     @api.objreg.register
     def __init__(self) -> None:
+        super().__init__()
         self._reset()
+        self._action = self._reverse_action = None
 
-    @api.commands.register()
-    def batchmark_start(self) -> None:
-        """Start Batch Mark Selection.
+        api.signals.escape_pressed.connect(self.batchmark_cancel)
+        api.signals.event_handled.connect(self._batchmark_update)
+        api.working_directory.handler.loaded.connect(self.batchmark_cancel)
 
-        Starts the selection at the currently selected image."""
-
-        self.paths = api.pathlist()
-        current_path = api.current_path()
-        self.start_index = self.paths.index(current_path)
-
-    @api.commands.register()
-    def batchmark_end(self) -> None:
-        """End Batch Mark Selection.
-
-        Ends the selection at the currently selected image. If at least one image in the
-        selection is unmarked, all images get markded. If all images are already marked,
-        they all get unmarked."""
-
-        if self.get_status() in (self.STATUS.idle, self.STATUS.invalid):
-            self._reset()
+    def _batchmark_update(self):
+        """Update the marked paths according to the current position."""
+        if self.get_status() != self.STATUS.started:
             return
 
         current_path = api.current_path()
         self.end_index = self.paths.index(current_path)
 
-        selected_paths = self.paths[self._get_lower_bound() : self._get_upper_bound()]
+        selected_paths = set(
+            self.paths[self._get_lower_bound() : self._get_upper_bound()]
+        )
 
-        all_marked = all(api.mark.is_marked(path) for path in selected_paths)
-        action = api.mark.Action.Unmark if all_marked else api.mark.Action.Mark
-        api.mark.mark(selected_paths, action)
+        no_longer_marked = self._triggered - selected_paths
 
+        api.mark.mark(selected_paths, self._action)
+        api.mark.mark(no_longer_marked, self._reverse_action)
+
+        self._triggered = selected_paths
+
+    @api.commands.register()
+    def batchmark_start(self) -> None:
+        """Start Batch Mark Selection at the current image.
+
+        In case the current image is marked, we will unmark the batch."""
+
+        self.paths = api.pathlist()
+        self._prev_marked = set(api.mark.paths)
+        current_path = api.current_path()
+        if api.mark.is_marked(current_path):
+            self._action = api.mark.Action.Unmark
+            self._reverse_action = api.mark.Action.Mark
+        else:
+            self._action = api.mark.Action.Mark
+            self._reverse_action = api.mark.Action.Unmark
+        self.start_index = self.paths.index(current_path)
+
+    @api.commands.register()
+    def batchmark_accept(self) -> None:
+        """Accept the changes of the current Batch Mark Selection."""
         self._reset()
 
     @api.commands.register()
     def batchmark_toggle(self) -> None:
-        """Starts and ends batchmark selection.
+        """Starts and ends Batch Mark Selection.
 
-        If not batchmark selection has been started or the last one is no longer valid
-        (e.g. when the path was changed) a batch mark is started. Else the batch mark
-        is ended and if at least one image in the selection is unmarked, all images get
-        markded. If all images are already marked, they all get unmarked."""
+        In case we are currently in Batch Mark, accept the changes. Otherwise start
+        Batch Mark."""
 
-        if self.get_status() in (self.STATUS.idle, self.STATUS.invalid):
-            self.batchmark_start()
-
-        elif self.get_status() == self.STATUS.started:
-            self.batchmark_end()
+        if self.get_status() == self.STATUS.started:
+            self.batchmark_accept()
             self._reset()
+        else:
+            self.batchmark_start()
 
     @api.commands.register()
     def batchmark_cancel(self) -> None:
-        """Cancels the batchmark selection if started."""
-
-        self._reset()
+        """Cancels the Batch Mark Selection if started."""
+        if self.get_status() == self.STATUS.started:
+            to_mark = self._triggered & self._prev_marked
+            to_unmark = self._triggered - self._prev_marked
+            api.mark.mark(to_mark, api.mark.Action.Mark)
+            api.mark.mark(to_unmark, api.mark.Action.Unmark)
+            self._reset()
 
     def get_status(self):
 
@@ -104,6 +121,8 @@ class BatchMark:
         self.start_index = None
         self.end_index = None
         self.paths = None
+        self._prev_marked = set()
+        self._triggered = set()
 
     def _get_lower_bound(self):
         return min(self.start_index, self.end_index)

--- a/__init__.py
+++ b/__init__.py
@@ -12,11 +12,6 @@ _logger = log.module_logger(__name__)
 
 
 class BatchMark(QObject):
-    class STATUS:
-        invalid = 0
-        idle = 1
-        started = 2
-
     @api.objreg.register
     def __init__(self) -> None:
         super().__init__()
@@ -27,16 +22,24 @@ class BatchMark(QObject):
         api.signals.event_handled.connect(self._batchmark_update)
         api.working_directory.handler.loaded.connect(self.batchmark_cancel)
 
+        _logger.debug("Initialized BatchMark")
+
     def _batchmark_update(self):
         """Update the marked paths according to the current position."""
-        if self.get_status() != self.STATUS.started:
+        if not self._is_started():
+            _logger.info("Need to start selection first")
             return
 
         current_path = api.current_path()
         self.end_index = self.paths.index(current_path)
 
         selected_paths = set(
-            self.paths[self._get_lower_bound() : self._get_upper_bound()]
+            self.paths[
+                min(self.start_index, self.end_index) : max(
+                    self.start_index, self.end_index
+                )
+                + 1
+            ]
         )
 
         no_longer_marked = self._triggered - selected_paths
@@ -63,10 +66,13 @@ class BatchMark(QObject):
             self._reverse_action = api.mark.Action.Unmark
         self.start_index = self.paths.index(current_path)
 
+        _logger.debug("New selection started")
+
     @api.commands.register()
     def batchmark_accept(self) -> None:
         """Accept the changes of the current Batch Mark Selection."""
         self._reset()
+        _logger.debug("Selection accepted")
 
     @api.commands.register()
     def batchmark_toggle(self) -> None:
@@ -75,44 +81,35 @@ class BatchMark(QObject):
         In case we are currently in Batch Mark, accept the changes. Otherwise start
         Batch Mark."""
 
-        if self.get_status() == self.STATUS.started:
+        if self._is_started():
             self.batchmark_accept()
-            self._reset()
         else:
             self.batchmark_start()
 
     @api.commands.register()
     def batchmark_cancel(self) -> None:
         """Cancels the Batch Mark Selection if started."""
-        if self.get_status() == self.STATUS.started:
+        if self._is_started():
             to_mark = self._triggered & self._prev_marked
             to_unmark = self._triggered - self._prev_marked
             api.mark.mark(to_mark, api.mark.Action.Mark)
             api.mark.mark(to_unmark, api.mark.Action.Unmark)
             self._reset()
+            _logger.debug("Selection cancelled")
+        else:
+            _logger.debug("Nothing to cancel")
 
-    def get_status(self):
-
+    def _is_started(self):
+        """Indicate if a selection has been started."""
         if self.paths is None or self.start_index is None:
-            return self.STATUS.idle
+            return False
 
-        paths = api.pathlist()
-
-        if paths != self.paths:
-            return self.STATUS.invalid
-
-        return self.STATUS.started
+        return True
 
     @api.status.module("{batchmark}")
     def batchmark(self) -> str:
-        status = self.get_status()
-
-        if status == self.STATUS.started:
+        if self._is_started():
             color = styles.get("base0d")
-            return wrap_style_span(f"color: {color}", "<b>+</b>")
-
-        if status == self.STATUS.invalid:
-            color = styles.get("base08")
             return wrap_style_span(f"color: {color}", "<b>+</b>")
 
         return ""
@@ -123,12 +120,6 @@ class BatchMark(QObject):
         self.paths = None
         self._prev_marked = set()
         self._triggered = set()
-
-    def _get_lower_bound(self):
-        return min(self.start_index, self.end_index)
-
-    def _get_upper_bound(self):
-        return max(self.start_index, self.end_index) + 1
 
 
 def init(*_args: Any, **_kwargs: Any) -> None:


### PR DESCRIPTION
Proof-of-concept of what I meant with "marking on-the-fly" in #3.

As soon as we run `:batchmark-start` paths are automatically (un-)marked. The shown changes can either be accepted (`:batchmark-accept`) or canceled (`:batchmark-cancel`).

In case we start on an image that is currently marked, all images in the selection (including the start of course) will be unmarked. Otherwise, all images in the selection will be marked.

This needs the `eventhandler-signals` branch in vimiv and is especially useful when binding `:batchmark-toggle` to `v` or `V`. My workflow is then: press `v` to start the mode and to accept any selection. Or: press `v` to start the mode and press `<escape>` to discard the changes in selection when I don't like them.

Let me know what you think of the general idea. Obviously code and documentation / README would require quite some cleanup. In principle I would be happy to merge this straight into vimiv and bind one of the mentioned keys as I find this plugin extremely useful in daily usage.